### PR TITLE
Different Device Roles for Host and VM

### DIFF
--- a/run.py
+++ b/run.py
@@ -599,7 +599,7 @@ class vCenterHandler:
                     # Create NetBox device
                     results["devices"].append(nbt.device(
                         name=truncate(obj_name, max_len=64),
-                        device_role=settings.DEVICE_ROLE,
+                        device_role=settings.DEVICE_ROLE_HOST,
                         device_type=obj_model,
                         platform="VMware ESXi",
                         site="vCenter",
@@ -715,7 +715,7 @@ class vCenterHandler:
                         status=int(
                             1 if obj.runtime.powerState == "poweredOn" else 0
                             ),
-                        role="Server",
+                        role=settings.DEVICE_ROLE_VM,
                         platform=platform,
                         memory=obj.config.hardware.memoryMB,
                         disk=int(sum([
@@ -1608,12 +1608,14 @@ class NetBoxHandler:
                 }],
             "device_roles": [
                 {
-                    "name": "Server",
-                    "slug": "server",
-                    "color": "9e9e9e",
+                    "name": settings.DEVICE_ROLE_VM,
                     "vm_role": True
                 }],
             }
+        if settings.DEVICE_ROLE_VM != settings.DEVICE_ROLE_HOST:
+            dependencies["device_roles"].append({
+                "name": settings.DEVICE_ROLE_HOST,
+            })
         # For each dependency of each type verify object exists
         log.info("Verifying all prerequisite objects exist in NetBox.")
         for dep_type in dependencies:

--- a/settings.example.py
+++ b/settings.example.py
@@ -25,7 +25,8 @@ DNS_SERVERS = ["192.168.1.11", "192.168.1.12"]
 # Create a custom field for virtual machines to track the current host they reside on
 TRACK_VM_HOST = False
 # Specify custom NetBox Device / vCenter Host role. Must match the name of an existing NetBox Device Role.
-DEVICE_ROLE = "Server"
+DEVICE_ROLE_HOST = "Server"
+DEVICE_ROLE_VM = "Server"
 # Allow the primary IP of a netbox object to be overwritten
 UPDATE_PRIMARY_IP = True
 


### PR DESCRIPTION
Replace the current Device Role setting with two different one for Hosts and VMs. Check them as dependencies. Use them for Hosts and VMs respectively